### PR TITLE
Make CharLCD work over anything that supports the GPIO interface

### DIFF
--- a/Adafruit_CharLCD/Adafruit_CharLCD.py
+++ b/Adafruit_CharLCD/Adafruit_CharLCD.py
@@ -6,7 +6,6 @@
 # LiquidCrystal - https://github.com/arduino/Arduino/blob/master/libraries/LiquidCrystal/LiquidCrystal.cpp
 #
 
-import RPi.GPIO as GPIO
 from time import sleep
 
 class Adafruit_CharLCD:
@@ -55,18 +54,22 @@ class Adafruit_CharLCD:
 
 
 
-    def __init__(self, pin_rs=25, pin_e=24, pins_db=[23, 17, 21, 22]):
-
+    def __init__(self, pin_rs=25, pin_e=24, pins_db=[23, 17, 21, 22], GPIO = None):
+	# Emulate the old behavior of using RPi.GPIO if we haven't been given
+	# an explicit GPIO interface to use
+	if not GPIO:
+	    import RPi.GPIO as GPIO
+   	self.GPIO = GPIO
         self.pin_rs = pin_rs
         self.pin_e = pin_e
         self.pins_db = pins_db
 
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setup(self.pin_e, GPIO.OUT)
-        GPIO.setup(self.pin_rs, GPIO.OUT)
+        self.GPIO.setmode(GPIO.BCM)
+        self.GPIO.setup(self.pin_e, GPIO.OUT)
+        self.GPIO.setup(self.pin_rs, GPIO.OUT)
 
         for pin in self.pins_db:
-            GPIO.setup(pin, GPIO.OUT)
+            self.GPIO.setup(pin, GPIO.OUT)
 
 	self.write4bits(0x33) # initialization
 	self.write4bits(0x32) # initialization
@@ -204,23 +207,23 @@ class Adafruit_CharLCD:
 
         bits=bin(bits)[2:].zfill(8)
 
-        GPIO.output(self.pin_rs, char_mode)
+        self.GPIO.output(self.pin_rs, char_mode)
 
         for pin in self.pins_db:
-            GPIO.output(pin, False)
+            self.GPIO.output(pin, False)
 
         for i in range(4):
             if bits[i] == "1":
-                GPIO.output(self.pins_db[::-1][i], True)
+                self.GPIO.output(self.pins_db[::-1][i], True)
 
 	self.pulseEnable()
 
         for pin in self.pins_db:
-            GPIO.output(pin, False)
+            self.GPIO.output(pin, False)
 
         for i in range(4,8):
             if bits[i] == "1":
-                GPIO.output(self.pins_db[::-1][i-4], True)
+                self.GPIO.output(self.pins_db[::-1][i-4], True)
 
 	self.pulseEnable()
 
@@ -231,11 +234,11 @@ class Adafruit_CharLCD:
 
 
     def pulseEnable(self):
-	GPIO.output(self.pin_e, False)
+	self.GPIO.output(self.pin_e, False)
 	self.delayMicroseconds(1)		# 1 microsecond pause - enable pulse must be > 450ns 
-	GPIO.output(self.pin_e, True)
+	self.GPIO.output(self.pin_e, True)
 	self.delayMicroseconds(1)		# 1 microsecond pause - enable pulse must be > 450ns 
-	GPIO.output(self.pin_e, False)
+	self.GPIO.output(self.pin_e, False)
 	self.delayMicroseconds(1)		# commands need > 37us to settle
 
 


### PR DESCRIPTION
This makes the GPIO be an object passed to the class (defaulting to the old behavior of using RPi.GPIO).   This in turn, makes it trivial to support any I2C expander that can  present the same interface as RPi.GPIO (which is trivial).

For example, when used with the code at [PCA95XX](http://github.com/dberlin/PCA95XX) you can hook the LCD up to a PCA9535/PCA9555, and use code like this to have it simply work with the LCD driver without any additional modifications:

``` python
from PCA95XX import PCA95XX_GPIO
from Adafruit_CharLCD import Adafruit_CharLCD

bus = PCA95XX_GPIO(0, 0x20, 16)
lcd = Adafruit_CharLCD(8, 9, [10, 11, 12, 13], bus)
```
