### PR TITLE
Update Adafruit_CharLCD/Adafruit_CharLCD.py - Weird Characters

### DIFF
--- a/Adafruit_CharLCD/Adafruit_CharLCD.py
+++ b/Adafruit_CharLCD/Adafruit_CharLCD.py
@@ -229,7 +229,7 @@ class Adafruit_CharLCD:
 
 
     def delayMicroseconds(self, microseconds):
-	seconds = microseconds / 1000000	# divide microseconds by 1 million for seconds
+	seconds = microseconds / float(1000000)	# divide microseconds by 1 million for seconds
 	sleep(seconds)
 
 


### PR DESCRIPTION
In delayMicroseconds(), it's always sleep(0) in Python 2.x (get a lot of weird characters on LCD)

This is because x / y returns an integer, not a float in Python 2.x
changed to: seconds = microseconds / float(1000000)
