### PR TITLE
Fix IOError string in Adafruit_I2C.py

### DIFF
--- a/Adafruit_I2C/Adafruit_I2C.py
+++ b/Adafruit_I2C/Adafruit_I2C.py
@@ -56,7 +56,7 @@ class Adafruit_I2C :
         print results
       return results
     except IOError, err:
-      print "Error accessing 09x%02X: Check your I2C address" % self.address
+      print "Error accessing 0x%02X: Check your I2C address" % self.address
       return -1
 
   def readU8(self, reg):


### PR DESCRIPTION
I was a bit thrown off by this error string at first. First time contributing; I hope this is the right method.
