### PR TITLE
Fix potentially broken symlinks in CharLCDPlate.

### DIFF
--- a/Adafruit_CharLCDPlate/Adafruit_I2C.py
+++ b/Adafruit_CharLCDPlate/Adafruit_I2C.py
@@ -1,1 +1,1 @@
-../../Adafruit-Raspberry-Pi-Python-Code/Adafruit_I2C/Adafruit_I2C.py
+../Adafruit_I2C/Adafruit_I2C.py

--- a/Adafruit_CharLCDPlate/Adafruit_MCP230xx.py
+++ b/Adafruit_CharLCDPlate/Adafruit_MCP230xx.py
@@ -1,1 +1,1 @@
-../../Adafruit-Raspberry-Pi-Python-Code/Adafruit_MCP230xx/Adafruit_MCP230xx.py
+../Adafruit_MCP230xx/Adafruit_MCP230xx.py


### PR DESCRIPTION
I noticed that the 2 symlinks in CharLCDPlate were broken in my cloned repo because I used a different name for the main repo directory and the relative path symlinks did a double ".." before entering the target directory.
