### PR TITLE
Adding End of Line handling and support for 20x4 displays

### DIFF
--- a/Adafruit_CharLCDPlate/Adafruit_CharLCDPlate.py
+++ b/Adafruit_CharLCDPlate/Adafruit_CharLCDPlate.py
@@ -257,8 +257,9 @@ class Adafruit_CharLCDPlate(Adafruit_I2C):
     # ----------------------------------------------------------------------
     # Utility methods
 
-    def begin(self, cols, lines):
+    def begin(self, cols = 16, lines = 2):
         self.currline = 0
+        self.cols = cols
         self.numlines = lines
         self.clear()
 
@@ -404,13 +405,35 @@ class Adafruit_CharLCDPlate(Adafruit_I2C):
         self.write(self.LCD_SETDDRAMADDR)
 
 
-    def message(self, text):
-        """ Send string to LCD. Newline wraps to second line"""
-        lines = str(text).split('\n')    # Split at newline(s)
-        for i, line in enumerate(lines): # For each substring...
-            if i > 0:                    # If newline(s),
-                self.write(0xC0)         #  set DDRAM address to 2nd line
-            self.write(line, True)       # Issue substring
+    def message(self, text, limitMode = 0):
+            """ Send string to LCD. Newline wraps to next line"""
+            lines = str(text).split('\n')       # Split at newline(s)
+            for i, line in enumerate(lines):    # For each substring...
+                if i == 1:                      # If newline(s),
+                    self.write(0xC0)             # set DDRAM address to 2nd line
+                elif i == 2:
+                    self.write(0x94)
+                elif i >= 3:
+                    self.write(0xD4)
+                """Now depending on the limit mode set by the function call this will handle """
+                lineLength = len(line)
+                limit = self.numcols
+                if limitMode <= 0: 
+                    self.write(line, True)     
+                elif lineLength >= limit and limitMode == 1:
+                    '''With the limit mode set to 1 the line is truncated 
+                    at the number of columns available on the display'''
+                    limitedLine = line[0:self.numcols]
+                    self.write(limitedLine, True)  
+                elif lineLength >= limit and limitMode == 2:
+                    '''With the limit mode set to 2 the line is truncated 
+                    at the number of columns minus 3 to add in an elipse'''
+                    limitedLine = line[0:self.numcols-3]+'...'
+                    self.write(limitedLine, True)
+                elif lineLength >= limit and limitMode >= 3:
+                    '''Future todo, add in proper, "line after line" cariage return'''
+                else:
+                    self.write(line, True)
 
 
     def backlight(self, color):


### PR DESCRIPTION
I was using this code with a RPi and the MCP230xx without the plate and found a need to update it with support for 20x4 (or any size that runs the HD44780 really) This also helps with some of the odd carriage return things. with more than 2 lines. See my test script for demos
