### PR TITLE
use the proper function for reading 16 bit values

### DIFF
--- a/Adafruit_I2C/Adafruit_I2C.py
+++ b/Adafruit_I2C/Adafruit_I2C.py
@@ -117,9 +117,7 @@ class Adafruit_I2C :
   def readU16(self, reg):
     "Reads an unsigned 16-bit value from the I2C device"
     try:
-      hibyte = self.readU8(reg)
-      lobyte = self.readU8(reg+1)
-      result = (hibyte << 8) + lobyte
+      result = self.bus.read_word_data(self.address,reg)
       if (self.debug):
         print "I2C: Device 0x%02X returned 0x%04X from reg 0x%02X" % (self.address, result & 0xFFFF, reg)
       return result


### PR DESCRIPTION
some devices (such as the MPR121 touch sensor) will malfunction if you try to read the 2 bytes separately
