### PR TITLE
Added function to calculate real/absolute pressure at sea level

### DIFF
--- a/Adafruit_BMP085/Adafruit_BMP085.py
+++ b/Adafruit_BMP085/Adafruit_BMP085.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import time
+from decimal import Decimal
 from Adafruit_I2C import Adafruit_I2C
 
 # ===========================================================================
@@ -257,3 +258,11 @@ class BMP085 :
     return altitude
 
     return 0
+
+  # With the measured pressure and the absolute altitude the pressure at sea level can be calculated
+  # see BMP085 datasheet: 3.7 Calculating pressure at sea level
+  def getRealPressure(self, altitude):
+    pressure = self.readPressure()
+    denominator = pow(Decimal(1) - (Decimal(altitude) / Decimal(44330)), Decimal(5.255))
+
+    return pressure / denominator

--- a/Adafruit_BMP085/Adafruit_BMP085_example.py
+++ b/Adafruit_BMP085/Adafruit_BMP085_example.py
@@ -21,6 +21,10 @@ temp = bmp.readTemperature()
 # Read the current barometric pressure level
 pressure = bmp.readPressure()
 
+# get the real barometric pressure on sea level
+# pass the absolute altitude of the sensors position as parameter
+realPressure = bmp.getRealPressure(720)
+
 # To calculate altitude based on an estimated mean sea level pressure
 # (1013.25 hPa) call the function as follows, but this won't be very accurate
 altitude = bmp.readAltitude()
@@ -32,4 +36,5 @@ altitude = bmp.readAltitude()
 
 print "Temperature: %.2f C" % temp
 print "Pressure:    %.2f hPa" % (pressure / 100.0)
+print "Real pressure: %.2f hPa" % (realPressure / 100)
 print "Altitude:    %.2f" % altitude


### PR DESCRIPTION
I added a function that gives the real pressure at sea level.
Reason: The BMP085 is configured for usage on sea level, so we have to do a compensation calculation to consider the altitude of the actual sensor position.

For more information take a look at the BMP085 datasheet chapter 3.7: "Calculating pressure at sea level" http://www.adafruit.com/datasheets/BMP085_DataSheet_Rev.1.0_01July2008.pdf
