### PR TITLE
prevent segfault caused by bitidx++

### DIFF
--- a/Adafruit_DHT_Driver/Adafruit_DHT.c
+++ b/Adafruit_DHT_Driver/Adafruit_DHT.c
@@ -105,7 +105,9 @@ int readDHT(int type, int pin) {
     }
     laststate = bcm2835_gpio_lev(pin);
     if (counter == 1000) break;
+#ifdef DEBUG
     bits[bitidx++] = counter;
+#endif
 
     if ((i>3) && (i%2 == 0)) {
       // shove each bit into the storage bytes


### PR DESCRIPTION
This patch modifies Adafruit_DHT_Driver/Adafruit_DHT.c so that the code
that increments `bitidx` without bound is protected by #ifdef DEBUG.
This prevents this code from generating a segfault if readDHT is called several
times (which will ultimately cause bitidx to increment beyond the end of the
bits array).

Resolves github issue #78.
