### PR TITLE
Fix bugs with getPiRevision and readS16

### DIFF
--- a/Adafruit_I2C/Adafruit_I2C.py
+++ b/Adafruit_I2C/Adafruit_I2C.py
@@ -132,7 +132,7 @@ class Adafruit_I2C :
   def readS16(self, reg, little_endian=True):
     "Reads a signed 16-bit value from the I2C device"
     try:
-      result = self.readU16(self.address,reg,little_endian)
+      result = self.readU16(reg,little_endian)
       if result > 32767: result -= 65536
       return result
     except IOError, err:


### PR DESCRIPTION
This pull fixes a couple small issues:
- getPiRevision's check for the revision 1 boards should check for revisions ending in '2' or '3' instead of '1' or '2'.  This is based on the revision info from here: http://elinux.org/RPi_HardwareHistory#Board_Revision_History  and looking at the latest quick2wire-python-api code which also now checks for 2 or 3.
- readS16 was actually returning unsigned values.  This fixes the function so it returns a signed value, and adds an optional little_endian=True or False parameter (defaults to true).  The endian parameter will make it explicit what endianness the caller desires since the underlying I2C read system calls assume little endian (which causes problems when reading big endian data like BMP085 sensor calibration).  
  
  Note that this is a potentially breaking change for code which currently uses readS16 and unknowingly depends on it actually returning incorrect unsigned values.  I searched the Adafruit github code and don't see anything depending the function so it should be safe to change.  For folks that have code that depends on this bug I think it's best to still make this fix and help them update their code going forward (either switching to readU16 or using readS16 with signed data correctly).
