### PR TITLE
Fixed PWM driver reset

### DIFF
--- a/Adafruit_I2C/Adafruit_I2C.py
+++ b/Adafruit_I2C/Adafruit_I2C.py
@@ -25,15 +25,14 @@ class Adafruit_I2C :
   def getPiI2CBusNumber():
     # Gets the I2C bus number /dev/i2c#
     return 1 if Adafruit_I2C.getPiRevision() > 1 else 0
- 
+
   def __init__(self, address, busnum=-1, debug=False):
     self.address = address
     # By default, the correct I2C bus is auto-detected using /proc/cpuinfo
     # Alternatively, you can hard-code the bus version below:
     # self.bus = smbus.SMBus(0); # Force I2C0 (early 256MB Pi's)
     # self.bus = smbus.SMBus(1); # Force I2C1 (512MB Pi's)
-    self.bus = smbus.SMBus(
-      busnum if busnum >= 0 else Adafruit_I2C.getPiI2CBusNumber())
+    self.bus = smbus.SMBus(busnum if busnum >= 0 else Adafruit_I2C.getPiI2CBusNumber())
     self.debug = debug
 
   def reverseByteOrder(self, data):
@@ -66,6 +65,15 @@ class Adafruit_I2C :
       if self.debug:
         print ("I2C: Wrote 0x%02X to register pair 0x%02X,0x%02X" %
          (value, reg, reg+1))
+    except IOError, err:
+      return self.errMsg()
+
+  def writeRaw8(self, value):
+    "Writes an 8-bit value on the bus"
+    try:
+      self.bus.write_byte(self.address, value)
+      if self.debug:
+        print "I2C: Wrote 0x%02X" % value
     except IOError, err:
       return self.errMsg()
 

--- a/Adafruit_PWM_Servo_Driver/Adafruit_PWM_Servo_Driver.py
+++ b/Adafruit_PWM_Servo_Driver/Adafruit_PWM_Servo_Driver.py
@@ -9,23 +9,35 @@ from Adafruit_I2C import Adafruit_I2C
 # ============================================================================
 
 class PWM :
-  i2c = None
-
   # Registers/etc.
+  __MODE1              = 0x00
+  __MODE2              = 0x01
   __SUBADR1            = 0x02
   __SUBADR2            = 0x03
   __SUBADR3            = 0x04
-  __MODE1              = 0x00
   __PRESCALE           = 0xFE
   __LED0_ON_L          = 0x06
   __LED0_ON_H          = 0x07
   __LED0_OFF_L         = 0x08
   __LED0_OFF_H         = 0x09
-  __ALLLED_ON_L        = 0xFA
-  __ALLLED_ON_H        = 0xFB
-  __ALLLED_OFF_L       = 0xFC
-  __ALLLED_OFF_H       = 0xFD
+  __ALL_LED_ON_L       = 0xFA
+  __ALL_LED_ON_H       = 0xFB
+  __ALL_LED_OFF_L      = 0xFC
+  __ALL_LED_OFF_H      = 0xFD
+
+  # Bits
+  __RESTART            = 0x80
   __SLEEP              = 0x10
+  __ALLCALL            = 0x01
+  __INVRT              = 0x10
+  __OUTDRV             = 0x04
+
+  general_call_i2c = Adafruit_I2C(0x00)
+
+  @classmethod
+  def softwareReset(cls):
+    "Sends a software reset (SWRST) command to all the servo drivers on the bus"
+    cls.general_call_i2c.writeRaw8(0x06)        # SWRST
 
   def __init__(self, address=0x40, debug=False):
     self.i2c = Adafruit_I2C(address)
@@ -33,8 +45,12 @@ class PWM :
     self.address = address
     self.debug = debug
     if (self.debug):
-      print "Reseting PCA9685"
-    self.i2c.bus.write_byte(0x00, 0x06)
+      print "Reseting PCA9685 MODE1 (without SLEEP) and MODE2"
+    self.setAllPWM(0, 0)
+    self.i2c.write8(self.__MODE2, self.__OUTDRV)
+    self.i2c.write8(self.__MODE1, self.__ALLCALL)
+    time.sleep(0.005)                                       # wait for oscillator
+    
     mode1 = self.i2c.readU8(self.__MODE1)
     mode1 = mode1 & ~self.__SLEEP                 # wake up (reset sleep)
     self.i2c.write8(self.__MODE1, mode1)
@@ -68,6 +84,9 @@ class PWM :
     self.i2c.write8(self.__LED0_OFF_L+4*channel, off & 0xFF)
     self.i2c.write8(self.__LED0_OFF_H+4*channel, off >> 8)
 
-
-
-
+  def setAllPWM(self, on, off):
+    "Sets a all PWM channels"
+    self.i2c.write8(self.__ALL_LED_ON_L, on & 0xFF)
+    self.i2c.write8(self.__ALL_LED_ON_H, on >> 8)
+    self.i2c.write8(self.__ALL_LED_OFF_L, off & 0xFF)
+    self.i2c.write8(self.__ALL_LED_OFF_H, off >> 8)


### PR DESCRIPTION
The previous implementation only set the `MODE1` register to `0x00`, which is not the default of the _PCA9685_ (bit 0, `ALLCALL`, defaults to 1 - see section 7.3.1 in the datasheet) and ignores all other register like `MODE2`, all output values, etc. The _PCA9685_ offers a dedicated software reset, which _"allows all the devices in the I2C-bus to be reset to the power-up state"_ (section 7.6).
