### PR TITLE
Fixed direction in the config function

### DIFF
--- a/Adafruit_MCP230xx/Adafruit_MCP230xx.py
+++ b/Adafruit_MCP230xx/Adafruit_MCP230xx.py
@@ -92,7 +92,7 @@ class Adafruit_MCP230XX(object):
             self.direction = self._readandchangepin(MCP23017_IODIRA, pin, mode)
         if self.num_gpios <= 16:
             if (pin < 8):
-                self.direction = self._readandchangepin(MCP23017_IODIRA, pin, mode)
+                self.direction |= self._readandchangepin(MCP23017_IODIRA, pin, mode)
             else:
                 self.direction |= self._readandchangepin(MCP23017_IODIRB, pin-8, mode) << 8
 


### PR DESCRIPTION
I think that the function _readandchangepin will return a 8-bit data, but the variant self.direction is a 16-bit one. Therefore, the original code will lead to losing the direction information of PORT B by masking off the most significant byte of the variant self.direction. Maybe the code should be changed as below.
change the code in Line 95:
self.direction = self._readandchangepin(MCP23017_IODIRA, pin, mode)
to 
self.direction |= self._readandchangepin(MCP23017_IODIRA, pin, mode)
