### PR TITLE
Refine 7-segment backpack to use inverted digits, and filled out clock example

### DIFF
--- a/Adafruit_LEDBackpack/Adafruit_7Segment.py
+++ b/Adafruit_LEDBackpack/Adafruit_7Segment.py
@@ -13,10 +13,15 @@ from Adafruit_LEDBackpack import LEDBackpack
 
 class SevenSegment:
   disp = None
- 
+  invert = False
+
   # Hexadecimal character lookup table (row 1 = 0..9, row 2 = A..F)
   digits = [ 0x3F, 0x06, 0x5B, 0x4F, 0x66, 0x6D, 0x7D, 0x07, 0x7F, 0x6F, \
              0x77, 0x7C, 0x39, 0x5E, 0x79, 0x71 ]
+
+  # The same, but upside-down
+  idigits = [ 0x3F, 0x30, 0x5B, 0x79, 0x74, 0x6D, 0x6F, 0x38, 0x7F, 0x7D, \
+              0x7E, 0x67, 0x0F, 0x73, 0x4F, 0x4E ]
 
   # Constructor
   def __init__(self, address=0x70, debug=False):
@@ -37,14 +42,23 @@ class SevenSegment:
       return
     if (value > 0xF):
       return
+
+    # Decide which digit set to use: check self.invert
+    d = self.idigits[value] if self.invert else self.digits[value]
+
+    # If inverted, also reverse the character positions
+    c = (4-charNumber) if self.invert else charNumber
+
     # Set the appropriate digit
-    self.disp.setBufferRow(charNumber, self.digits[value] | (dot << 7))
+    self.disp.setBufferRow(c, d | (dot << 7))
 
   def setColon(self, state=True):
     "Enables or disables the colon character"
     # Warning: This function assumes that the colon is character '2',
     # which is the case on 4 char displays, but may need to be modified
     # if another display type is used
+    # This sets all non-digit LEDs.  Change (2,0xFFFF) to (2,2) to just
+    # set colon on the 1.2" 7-Segment display.
     if (state):
       self.disp.setBufferRow(2, 0xFFFF)
     else:

--- a/Adafruit_LEDBackpack/ex_7segment_clock.py
+++ b/Adafruit_LEDBackpack/ex_7segment_clock.py
@@ -9,6 +9,12 @@ from Adafruit_7Segment import SevenSegment
 # ===========================================================================
 segment = SevenSegment(address=0x70)
 
+# Set segment.invert = True if unit is upside-down
+segment.invert = False
+
+# Set brightness between 0 (off) and 15 (full) if you value your retinae
+segment.disp.setBrightness(1)
+
 print "Press CTRL+Z to exit"
 
 # Continually update the time on a 4 char, 7-segment display


### PR DESCRIPTION
This could benefit from better handling of colons and dots, but that's already affected by which backpack / display is used.
