### PR TITLE
Suggested fix for direction caching problem in MCP230xx

### DIFF
--- a/Adafruit_MCP230xx/Adafruit_MCP230xx.py
+++ b/Adafruit_MCP230xx/Adafruit_MCP230xx.py
@@ -96,7 +96,7 @@ class Adafruit_MCP230XX(object):
             if (pin < 8):
                 directionA = self._readandchangepin(MCP23017_IODIRA, pin, mode)
             else:
-                directionB = self._readandchangepin(MCP23017_IODIRB, pin-8, mode) << 8
+                directionB = self._readandchangepin(MCP23017_IODIRB, pin-8, mode)
             self.direction = ((directionB << 8) | directionA)
 
         return self.direction

--- a/Adafruit_MCP230xx/Adafruit_MCP230xx.py
+++ b/Adafruit_MCP230xx/Adafruit_MCP230xx.py
@@ -91,10 +91,13 @@ class Adafruit_MCP230XX(object):
         if self.num_gpios <= 8:
             self.direction = self._readandchangepin(MCP23017_IODIRA, pin, mode)
         if self.num_gpios <= 16:
+            directionA = self.direction & 0xFF
+            directionB = self.direction >> 8
             if (pin < 8):
-                self.direction = self._readandchangepin(MCP23017_IODIRA, pin, mode)
+                directionA = self._readandchangepin(MCP23017_IODIRA, pin, mode)
             else:
-                self.direction |= self._readandchangepin(MCP23017_IODIRB, pin-8, mode) << 8
+                directionB = self._readandchangepin(MCP23017_IODIRB, pin-8, mode) << 8
+            self.direction = ((directionB << 8) | directionA)
 
         return self.direction
 


### PR DESCRIPTION
If, after setting pin direction on bank B, you set a pin direction on bank A, the direction cache is overwritten with only bank A data.  Suggested fix separates direction variables for banks A and B, overwrites as needed, and integrates the two banks back into direction cache.
