### PR TITLE
Adding pin and sample code for LCDs with backlights using I2C/SPI LCD Backpack 

### DIFF
--- a/Adafruit_CharLCD/Adafruit_CharLCD.py
+++ b/Adafruit_CharLCD/Adafruit_CharLCD.py
@@ -53,7 +53,7 @@ class Adafruit_CharLCD(object):
     LCD_5x10DOTS            = 0x04
     LCD_5x8DOTS             = 0x00
 
-    def __init__(self, pin_rs=25, pin_e=24, pins_db=[23, 17, 21, 22], GPIO=None):
+    def __init__(self, pin_rs=25, pin_e=24, pins_db=[23, 17, 21, 22], GPIO=None, pin_b=19):
         # Emulate the old behavior of using RPi.GPIO if we haven't been given
         # an explicit GPIO interface to use
         if not GPIO:
@@ -63,10 +63,12 @@ class Adafruit_CharLCD(object):
         self.pin_rs = pin_rs
         self.pin_e = pin_e
         self.pins_db = pins_db
+        self.pin_b = pin_b
 
         self.GPIO.setmode(GPIO.BCM)
         self.GPIO.setup(self.pin_e, GPIO.OUT)
         self.GPIO.setup(self.pin_rs, GPIO.OUT)
+        self.GPIO.setup(self.pin_b, GPIO.OUT)
 
         for pin in self.pins_db:
             self.GPIO.setup(pin, GPIO.OUT)
@@ -202,7 +204,10 @@ class Adafruit_CharLCD(object):
                 self.write4bits(0xC0)  # next line
             else:
                 self.write4bits(ord(char), True)
-
+    
+    def backlight(self, status):
+        """ Turn LCD panel backlight on or off """
+        self.GPIO.output(self.pin_b, status)
 
 if __name__ == '__main__':
     lcd = Adafruit_CharLCD()

--- a/Adafruit_CharLCD/LCD_MCP230XX_test.py
+++ b/Adafruit_CharLCD/LCD_MCP230XX_test.py
@@ -12,7 +12,10 @@ gpio_count = 8  # Number of GPIOs exposed by the MCP230xx chip, should be 8 or 1
 mcp = MCP230XX_GPIO(bus, address, gpio_count)
 
 # Create LCD, passing in MCP GPIO adapter.
-lcd = Adafruit_CharLCD(pin_rs=1, pin_e=2, pins_db=[3,4,5,6], GPIO=mcp)
+lcd = Adafruit_CharLCD(pin_rs=1, pin_e=2, pins_db=[3,4,5,6], GPIO=mcp, pin_b=7)
+
+# Turn LCD backlight on or off. 
+# lcd.backlight(True)
 
 lcd.clear()
 lcd.message("  Adafruit 16x2\n  Standard LCD")


### PR DESCRIPTION
The Adafruit_CharLCD library did not have default code for handling LCDs with backlights. I have set a new default (pin_b) in the initializer to pin 19 for RPi.GPIO and pin 7 in the sample code using the I2C/SPI Backpack with Adafruit_MCP230xx chip. 
