### PR TITLE
Two small changes:

### DIFF
--- a/Adafruit_VCNL4000/Adafruit_VCNL4000.py
+++ b/Adafruit_VCNL4000/Adafruit_VCNL4000.py
@@ -46,16 +46,16 @@ class VCNL4000 :
   def read_proximity(self):
     self.i2c.write8(VCNL4000_COMMAND, VCNL4000_MEASUREPROXIMITY)
     while True:
-      result = self.i2c.readU8(VCNL4000_COMMAND)
-      if (result and VCNL4000_PROXIMITYREADY):
-        return self.i2c.readU16(VCNL4000_PROXIMITYDATA)
       time.sleep(0.001)
+      result = self.i2c.readU8(VCNL4000_COMMAND)
+      if (result & VCNL4000_PROXIMITYREADY):
+        return self.i2c.readU16(VCNL4000_PROXIMITYDATA)
 
   # Read data from ambient sensor  
   def read_ambient(self):
     self.i2c.write8(VCNL4000_COMMAND, VCNL4000_MEASUREAMBIENT)
     while True:
-      result = self.i2c.readU8(VCNL4000_COMMAND)
-      if (result and VCNL4000_AMBIENTREADY):
-        return self.i2c.readU16(VCNL4000_AMBIENTDATA)
       time.sleep(0.001)
+      result = self.i2c.readU8(VCNL4000_COMMAND)
+      if (result & VCNL4000_AMBIENTREADY):
+        return self.i2c.readU16(VCNL4000_AMBIENTDATA)


### PR DESCRIPTION
1. Fixed bug where boolean "and" was incorrectly used instead of bitwise "&".  We're testing a bit in a byte.
2. Moved the sleep call to BEFORE the first read.  Occasional errors with immediate read after write.

Regarding the issue of moving the sleep command, I can't be sure this isn't a solution to a software bug or an issue with the device.  I did find evidence of people having similar trouble and one instance where someone theorized that the "write" operation sucked too much power, causing the following read operation to fail, but that might be silliness.  All I can say for certain is that this appears to make the problem go away. 
