### PR TITLE
Fix bug: read state of an output PIN

### DIFF
--- a/Adafruit_MCP230xx/Adafruit_MCP230xx.py
+++ b/Adafruit_MCP230xx/Adafruit_MCP230xx.py
@@ -116,7 +116,7 @@ class Adafruit_MCP230XX(object):
 
     def input(self, pin):
         assert pin >= 0 and pin < self.num_gpios, "Pin number %s is invalid, only 0-%s are valid" % (pin, self.num_gpios)
-        assert self.direction & (1 << pin) != 0, "Pin %s not set to input" % pin
+        #assert self.direction & (1 << pin) != 0, "Pin %s not set to input" % pin
         if self.num_gpios <= 8:
             value = self.i2c.readU8(MCP23008_GPIOA)
         elif self.num_gpios > 8 and self.num_gpios <= 16:


### PR DESCRIPTION
Hello guys,

This commit fix the following problem:
# configure pin as output

mcp.config(13,mcp.OUTPUT)
mcp.output(13,1)
# read state

mcp.input(13) >> 13
# the result is 1

But if I configure 2 pins as output, I can't read the state
# configure pins as output

mcp.config(13,mcp.OUTPUT)
mcp.output(13,1)
mcp.config(14,mcp.OUTPUT)
# read state

mcp.input(13) >> 13
# raise : Pin 13 not set to input

If you need more informations, don't hesitate.
Joris
