### PR TITLE
Fix bug in config with pin values < 8

### DIFF
--- a/Adafruit_MCP230xx/Adafruit_MCP230xx.py
+++ b/Adafruit_MCP230xx/Adafruit_MCP230xx.py
@@ -92,9 +92,9 @@ class Adafruit_MCP230XX(object):
             self.direction = self._readandchangepin(MCP23017_IODIRA, pin, mode)
         if self.num_gpios <= 16:
             if (pin < 8):
-                self.direction = self._readandchangepin(MCP23017_IODIRA, pin, mode)
+                self.direction = (self.direction & 0b1111111100000000) +  self._readandchangepin(MCP23017_IODIRA, pin, mode)
             else:
-                self.direction |= self._readandchangepin(MCP23017_IODIRB, pin-8, mode) << 8
+                self.direction = (self.direction & 0b0000000011111111) + (self._readandchangepin(MCP23017_IODIRB, pin-8, mode) << 8)
 
         return self.direction
 


### PR DESCRIPTION
I think original code used to truncate the self.direction variable down to 8bits when a pin < 8 mode was changed.
The change keeps the upper 8 bits unchanged when pin < 8 and lower bits unchanged when pin >=8
My change is very explicit and could be made more pythonic :)
