### PR TITLE
Bug fix: signed differential sample values are ignored in ADS1015 (12 bi...

### DIFF
--- a/Adafruit_ADS1x15/Adafruit_ADS1x15.py
+++ b/Adafruit_ADS1x15/Adafruit_ADS1x15.py
@@ -289,7 +289,11 @@ class ADS1x15:
     result = self.i2c.readList(self.__ADS1015_REG_POINTER_CONVERT, 2)
     if (self.ic == self.__IC_ADS1015):
     	# Shift right 4 bits for the 12-bit ADS1015 and convert to mV
-    	return ( ((result[0] << 8) | (result[1] & 0xFF)) >> 4 )*pga/2048.0
+	val = ((result[0] << 8) | (result[1] & 0xFF)) >> 4
+	# (Take signed values into account as well)
+	if val >> 11:
+		val = val - 0xfff
+    	return val*pga/2048.0
     else:
 	# Return a mV value for the ADS1115
 	# (Take signed values into account as well)


### PR DESCRIPTION
When using ADS1015, ADS1x15.readADCDifferential method ignores signed inputs,
So positive samples make sense, but negative samples are returned as high values. This is especially frustrating in samples that oscillate around 0mV.
The fix is checking the most significant bit (11) and subtract the max value (0xFFF) from the signed sample if necessary, much like the 16 bit version.
Enjoy 