### PR TITLE
Added getKeys() method to read key presses recorded by HT16K33 keyscan

### DIFF
--- a/Adafruit_LEDBackpack/Adafruit_LEDBackpack.py
+++ b/Adafruit_LEDBackpack/Adafruit_LEDBackpack.py
@@ -16,6 +16,9 @@ class LEDBackpack:
   __HT16K33_REGISTER_SYSTEM_SETUP         = 0x20
   __HT16K33_REGISTER_DIMMING              = 0xE0
 
+  # Data base addresses
+  __HT16K33_ADDRESS_KEY_DATA              = 0x40
+
   # Blink rate
   __HT16K33_BLINKRATE_OFF                 = 0x00
   __HT16K33_BLINKRATE_2HZ                 = 0x01
@@ -83,6 +86,12 @@ class LEDBackpack:
       bytes.append((item >> 8) & 0xFF)
     self.i2c.writeList(0x00, bytes)
 
+  def getKeys(self, row):
+    "Returns a row of scanned key press values as a single 13-bit value (K13:K1)"
+    if (row > 2):
+      return
+    return self.i2c.readU16(self.__HT16K33_ADDRESS_KEY_DATA + row*2)
+
   def clear(self, update=True):
     "Clears the display memory"
     self.__buffer = [ 0, 0, 0, 0, 0, 0, 0, 0 ]
@@ -90,4 +99,3 @@ class LEDBackpack:
       self.writeDisplay()
 
 led = LEDBackpack(0x70)
-


### PR DESCRIPTION
Although the HT16K33 (the "LEDBackpack") is commonly used to drive LEDs, it is also able to scan keys arranged in a 13 x 3 matrix.
I needed to be able to read some jumpers (just like keys, but always on or off) to a HT16K33-based display project I'm working on, so I added a "getKeys()" method to Adafruit_LEDBackpack, which returns the current key scan result for a given row of 13 keys, as a 13-bit value where a '1' indicated a (debounced) key press since the last read. Note that if a key remains pressed, it will continue to be seen (return a '1') in subsequent scans.
For example, if keys 3 and 5 in row 0 have been pressed, getKeys(0) will return 0b0000000010100.