### PR TITLE
Removed unnecessary 'led = LEDBackpack(0x70)' line

### DIFF
--- a/Adafruit_LEDBackpack/Adafruit_LEDBackpack.py
+++ b/Adafruit_LEDBackpack/Adafruit_LEDBackpack.py
@@ -98,4 +98,3 @@ class LEDBackpack:
     if (update):
       self.writeDisplay()
 
-led = LEDBackpack(0x70)


### PR DESCRIPTION
The final line in Adafruit_LEDBackpack.py is not necessary - it does nothing.
More importantly, it contains a hard coded I2C address (0x70), creating errors if the address of the LEDBackpack is changed from the default 0x70.
These errors disappear if this unnecessary line is removed.
