### PR TITLE
Print-statement corrections & indentation fixes

### DIFF
--- a/Adafruit_ADS1x15/Adafruit_ADS1x15.py
+++ b/Adafruit_ADS1x15/Adafruit_ADS1x15.py
@@ -11,8 +11,8 @@ from Adafruit_I2C import Adafruit_I2C
 # Updates and new functions implementation by Pedro Villanueva, 03/2013.
 # The only error in the original code was in line 57:
 #              __ADS1015_REG_CONFIG_DR_920SPS    = 0x0050
-# should be 
-#              __ADS1015_REG_CONFIG_DR_920SPS    = 0x0060     
+# should be
+#              __ADS1015_REG_CONFIG_DR_920SPS    = 0x0060
 #
 # NOT IMPLEMENTED: Conversion ready pin, page 15 datasheet.
 # ===========================================================================
@@ -59,7 +59,7 @@ class ADS1x15:
   __ADS1015_REG_CONFIG_MODE_CONTIN  = 0x0000  # Continuous conversion mode
   __ADS1015_REG_CONFIG_MODE_SINGLE  = 0x0100  # Power-down single-shot mode (default)
 
-  __ADS1015_REG_CONFIG_DR_MASK      = 0x00E0  
+  __ADS1015_REG_CONFIG_DR_MASK      = 0x00E0
   __ADS1015_REG_CONFIG_DR_128SPS    = 0x0000  # 128 samples per second
   __ADS1015_REG_CONFIG_DR_250SPS    = 0x0020  # 250 samples per second
   __ADS1015_REG_CONFIG_DR_490SPS    = 0x0040  # 490 samples per second
@@ -94,8 +94,8 @@ class ADS1x15:
   __ADS1015_REG_CONFIG_CQUE_2CONV   = 0x0001  # Assert ALERT/RDY after two conversions
   __ADS1015_REG_CONFIG_CQUE_4CONV   = 0x0002  # Assert ALERT/RDY after four conversions
   __ADS1015_REG_CONFIG_CQUE_NONE    = 0x0003  # Disable the comparator and put ALERT/RDY in high state (default)
-  
-  
+
+
   # Dictionaries with the sampling speed values
   # These simplify and clean the code (avoid the abuse of if/elif/else clauses)
   spsADS1115 = {
@@ -107,7 +107,7 @@ class ADS1x15:
     250:__ADS1115_REG_CONFIG_DR_250SPS,
     475:__ADS1115_REG_CONFIG_DR_475SPS,
     860:__ADS1115_REG_CONFIG_DR_860SPS
-  }    
+  }
   spsADS1015 = {
     128:__ADS1015_REG_CONFIG_DR_128SPS,
     250:__ADS1015_REG_CONFIG_DR_250SPS,
@@ -125,8 +125,8 @@ class ADS1x15:
     1024:__ADS1015_REG_CONFIG_PGA_1_024V,
     512:__ADS1015_REG_CONFIG_PGA_0_512V,
     256:__ADS1015_REG_CONFIG_PGA_0_256V
-  }    
-  
+  }
+
 
   # Constructor
   def __init__(self, address=0x48, ic=__IC_ADS1015, debug=False):
@@ -146,32 +146,32 @@ class ADS1x15:
       return -1
     else:
       self.ic = ic
-        
+
     # Set pga value, so that getLastConversionResult() can use it,
     # any function that accepts a pga value must update this.
-    self.pga = 6144    
-  
-    
+    self.pga = 6144
+
+
   def readADCSingleEnded(self, channel=0, pga=6144, sps=250):
     "Gets a single-ended ADC reading from the specified channel in mV. \
     The sample rate for this mode (single-shot) can be used to lower the noise \
     (low sps) or to lower the power consumption (high sps) by duty cycling, \
     see datasheet page 14 for more info. \
     The pga must be given in mV, see page 13 for the supported values."
-    
+
     # With invalid channel return -1
     if (channel > 3):
       if (self.debug):
         print "ADS1x15: Invalid channel specified: %d" % channel
       return -1
-    
+
     # Disable comparator, Non-latching, Alert/Rdy active low
     # traditional comparator, single-shot mode
     config = self.__ADS1015_REG_CONFIG_CQUE_NONE    | \
              self.__ADS1015_REG_CONFIG_CLAT_NONLAT  | \
              self.__ADS1015_REG_CONFIG_CPOL_ACTVLOW | \
              self.__ADS1015_REG_CONFIG_CMODE_TRAD   | \
-             self.__ADS1015_REG_CONFIG_MODE_SINGLE    
+             self.__ADS1015_REG_CONFIG_MODE_SINGLE
 
     # Set sample per seconds, defaults to 250sps
     # If sps is in the dictionary (defined in init) it returns the value of the constant
@@ -179,13 +179,13 @@ class ADS1x15:
     if (self.ic == self.__IC_ADS1015):
       config |= self.spsADS1015.setdefault(sps, self.__ADS1015_REG_CONFIG_DR_1600SPS)
     else:
-      if ( (sps not in self.spsADS1115) & self.debug):	  
-	print "ADS1x15: Invalid pga specified: %d, using 6144mV" % sps     
+      if ( (sps not in self.spsADS1115) & self.debug):
+        print "ADS1x15: Invalid sps specified: %d, using 250sps" % sps
       config |= self.spsADS1115.setdefault(sps, self.__ADS1115_REG_CONFIG_DR_250SPS)
 
     # Set PGA/voltage range, defaults to +-6.144V
-    if ( (pga not in self.pgaADS1x15) & self.debug):	  
-      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % sps     
+    if ( (pga not in self.pgaADS1x15) & self.debug):
+      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % pga
     config |= self.pgaADS1x15.setdefault(pga, self.__ADS1015_REG_CONFIG_PGA_6_144V)
     self.pga = pga
 
@@ -215,17 +215,17 @@ class ADS1x15:
     # Read the conversion results
     result = self.i2c.readList(self.__ADS1015_REG_POINTER_CONVERT, 2)
     if (self.ic == self.__IC_ADS1015):
-    	# Shift right 4 bits for the 12-bit ADS1015 and convert to mV
-    	return ( ((result[0] << 8) | (result[1] & 0xFF)) >> 4 )*pga/2048.0
+      # Shift right 4 bits for the 12-bit ADS1015 and convert to mV
+      return ( ((result[0] << 8) | (result[1] & 0xFF)) >> 4 )*pga/2048.0
     else:
-	# Return a mV value for the ADS1115
-	# (Take signed values into account as well)
-	val = (result[0] << 8) | (result[1])
-	if val > 0x7FFF:
-	  return (val - 0xFFFF)*pga/32768.0
-	else:
-	  return ( (result[0] << 8) | (result[1]) )*pga/32768.0
-	
+      # Return a mV value for the ADS1115
+      # (Take signed values into account as well)
+      val = (result[0] << 8) | (result[1])
+      if val > 0x7FFF:
+        return (val - 0xFFFF)*pga/32768.0
+      else:
+        return ( (result[0] << 8) | (result[1]) )*pga/32768.0
+
 
   def readADCDifferential(self, chP=0, chN=1, pga=6144, sps=250):
     "Gets a differential ADC reading from channels chP and chN in mV. \
@@ -233,15 +233,15 @@ class ADS1x15:
     (low sps) or to lower the power consumption (high sps) by duty cycling, \
     see data sheet page 14 for more info. \
     The pga must be given in mV, see page 13 for the supported values."
-    
+
     # Disable comparator, Non-latching, Alert/Rdy active low
-    # traditional comparator, single-shot mode    
+    # traditional comparator, single-shot mode
     config = self.__ADS1015_REG_CONFIG_CQUE_NONE    | \
              self.__ADS1015_REG_CONFIG_CLAT_NONLAT  | \
              self.__ADS1015_REG_CONFIG_CPOL_ACTVLOW | \
              self.__ADS1015_REG_CONFIG_CMODE_TRAD   | \
-             self.__ADS1015_REG_CONFIG_MODE_SINGLE  
-    
+             self.__ADS1015_REG_CONFIG_MODE_SINGLE
+
     # Set channels
     if ( (chP == 0) & (chN == 1) ):
       config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_0_1
@@ -250,25 +250,25 @@ class ADS1x15:
     elif ( (chP == 2) & (chN == 3) ):
       config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_2_3
     elif ( (chP == 1) & (chN == 3) ):
-      config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_1_3  
+      config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_1_3
     else:
       if (self.debug):
-	print "ADS1x15: Invalid channels specified: %d, %d" % (chP, chN)
-	return -1
-         
+        print "ADS1x15: Invalid channels specified: %d, %d" % (chP, chN)
+      return -1
+
     # Set sample per seconds, defaults to 250sps
     # If sps is in the dictionary (defined in init()) it returns the value of the constant
     # othewise it returns the value for 250sps. This saves a lot of if/elif/else code!
     if (self.ic == self.__IC_ADS1015):
       config |= self.spsADS1015.setdefault(sps, self.__ADS1015_REG_CONFIG_DR_1600SPS)
     else:
-      if ( (sps not in self.spsADS1115) & self.debug):	  
-	print "ADS1x15: Invalid pga specified: %d, using 6144mV" % sps     
+      if ( (sps not in self.spsADS1115) & self.debug):
+        print "ADS1x15: Invalid sps specified: %d, using 250sps" % sps
       config |= self.spsADS1115.setdefault(sps, self.__ADS1115_REG_CONFIG_DR_250SPS)
-  
+
     # Set PGA/voltage range, defaults to +-6.144V
-    if ( (pga not in self.pgaADS1x15) & self.debug):	  
-      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % sps     
+    if ( (pga not in self.pgaADS1x15) & self.debug):
+      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % pga
     config |= self.pgaADS1x15.setdefault(pga, self.__ADS1015_REG_CONFIG_PGA_6_144V)
     self.pga = pga
 
@@ -288,20 +288,20 @@ class ADS1x15:
     # Read the conversion results
     result = self.i2c.readList(self.__ADS1015_REG_POINTER_CONVERT, 2)
     if (self.ic == self.__IC_ADS1015):
-    	# Shift right 4 bits for the 12-bit ADS1015 and convert to mV
-	val = ((result[0] << 8) | (result[1] & 0xFF)) >> 4
-	# (Take signed values into account as well)
-	if val >> 11:
-		val = val - 0xfff
-    	return val*pga/2048.0
+      # Shift right 4 bits for the 12-bit ADS1015 and convert to mV
+      val = ((result[0] << 8) | (result[1] & 0xFF)) >> 4
+      # (Take signed values into account as well)
+      if val >> 11:
+        val = val - 0xfff
+        return val*pga/2048.0
     else:
-	# Return a mV value for the ADS1115
-	# (Take signed values into account as well)
-	val = (result[0] << 8) | (result[1])
-	if val > 0x7FFF:
-	  return (val - 0xFFFF)*pga/32768.0
-	else:
-	  return ( (result[0] << 8) | (result[1]) )*pga/32768.0
+      # Return a mV value for the ADS1115
+      # (Take signed values into account as well)
+      val = (result[0] << 8) | (result[1])
+      if val > 0x7FFF:
+        return (val - 0xFFFF)*pga/32768.0
+      else:
+        return ( (result[0] << 8) | (result[1]) )*pga/32768.0
 
 
   def readADCDifferential01(self, pga=6144, sps=250):
@@ -311,8 +311,8 @@ class ADS1x15:
     see data sheet page 14 for more info. \
     The pga must be given in mV, see page 13 for the supported values."
     return self.readADCDifferential(0, 1, pga, sps)
-   
-  
+
+
   def readADCDifferential03(self, pga=6144, sps=250):
     "Gets a differential ADC reading from channels 0 and 3 in mV \
     The sample rate for this mode (single-shot) can be used to lower the noise \
@@ -320,15 +320,15 @@ class ADS1x15:
     see data sheet page 14 for more info. \
     The pga must be given in mV, see page 13 for the supported values."
     return self.readADCDifferential(0, 3, pga, sps)
-     
-  
+
+
   def readADCDifferential13(self, pga=6144, sps=250):
     "Gets a differential ADC reading from channels 1 and 3 in mV \
     The sample rate for this mode (single-shot) can be used to lower the noise \
     (low sps) or to lower the power consumption (high sps) by duty cycling, \
     see data sheet page 14 for more info. \
     The pga must be given in mV, see page 13 for the supported values."
-    return self.__readADCDifferential(1, 3, pga, sps)  
+    return self.__readADCDifferential(1, 3, pga, sps)
 
 
   def readADCDifferential23(self, pga=6144, sps=250):
@@ -337,23 +337,23 @@ class ADS1x15:
     (low sps) or to lower the power consumption (high sps) by duty cycling, \
     see data sheet page 14 for more info. \
     The pga must be given in mV, see page 13 for the supported values."
-    return self.readADCDifferential(2, 3, pga, sps)   
-  
-  
-  def startContinuousConversion(self, channel=0, pga=6144, sps=250): 
+    return self.readADCDifferential(2, 3, pga, sps)
+
+
+  def startContinuousConversion(self, channel=0, pga=6144, sps=250):
     "Starts the continuous conversion mode and returns the first ADC reading \
     in mV from the specified channel. \
     The sps controls the sample rate. \
     The pga must be given in mV, see datasheet page 13 for the supported values. \
     Use getLastConversionResults() to read the next values and \
     stopContinuousConversion() to stop converting."
-    
+
     # Default to channel 0 with invalid channel, or return -1?
     if (channel > 3):
       if (self.debug):
-	print "ADS1x15: Invalid channel specified: %d" % channel
+        print "ADS1x15: Invalid channel specified: %d" % channel
       return -1
-    
+
     # Disable comparator, Non-latching, Alert/Rdy active low
     # traditional comparator, continuous mode
     # The last flag is the only change we need, page 11 datasheet
@@ -361,7 +361,7 @@ class ADS1x15:
              self.__ADS1015_REG_CONFIG_CLAT_NONLAT  | \
              self.__ADS1015_REG_CONFIG_CPOL_ACTVLOW | \
              self.__ADS1015_REG_CONFIG_CMODE_TRAD   | \
-             self.__ADS1015_REG_CONFIG_MODE_CONTIN    
+             self.__ADS1015_REG_CONFIG_MODE_CONTIN
 
     # Set sample per seconds, defaults to 250sps
     # If sps is in the dictionary (defined in init()) it returns the value of the constant
@@ -369,16 +369,16 @@ class ADS1x15:
     if (self.ic == self.__IC_ADS1015):
       config |= self.spsADS1015.setdefault(sps, self.__ADS1015_REG_CONFIG_DR_1600SPS)
     else:
-      if ( (sps not in self.spsADS1115) & self.debug):	  
-	print "ADS1x15: Invalid pga specified: %d, using 6144mV" % sps     
+      if ( (sps not in self.spsADS1115) & self.debug):
+        print "ADS1x15: Invalid sps specified: %d, using 250sps" % sps
       config |= self.spsADS1115.setdefault(sps, self.__ADS1115_REG_CONFIG_DR_250SPS)
-  
+
     # Set PGA/voltage range, defaults to +-6.144V
-    if ( (pga not in self.pgaADS1x15) & self.debug):	  
-      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % sps     
+    if ( (pga not in self.pgaADS1x15) & self.debug):
+      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % pga
     config |= self.pgaADS1x15.setdefault(pga, self.__ADS1015_REG_CONFIG_PGA_6_144V)
-    self.pga = pga 
-    
+    self.pga = pga
+
     # Set the channel to be converted
     if channel == 3:
       config |= self.__ADS1015_REG_CONFIG_MUX_SINGLE_3
@@ -387,8 +387,8 @@ class ADS1x15:
     elif channel == 1:
       config |= self.__ADS1015_REG_CONFIG_MUX_SINGLE_1
     else:
-      config |= self.__ADS1015_REG_CONFIG_MUX_SINGLE_0    
-  
+      config |= self.__ADS1015_REG_CONFIG_MUX_SINGLE_0
+
     # Set 'start single-conversion' bit to begin conversions
     # No need to change this for continuous mode!
     config |= self.__ADS1015_REG_CONFIG_OS_SINGLE
@@ -404,29 +404,29 @@ class ADS1x15:
     # We add 0.5ms to be sure
     delay = 1.0/sps+0.0005
     time.sleep(delay)
-  
+
     # Read the conversion results
     result = self.i2c.readList(self.__ADS1015_REG_POINTER_CONVERT, 2)
     if (self.ic == self.__IC_ADS1015):
-    	# Shift right 4 bits for the 12-bit ADS1015 and convert to mV
-    	return ( ((result[0] << 8) | (result[1] & 0xFF)) >> 4 )*pga/2048.0
+      # Shift right 4 bits for the 12-bit ADS1015 and convert to mV
+      return ( ((result[0] << 8) | (result[1] & 0xFF)) >> 4 )*pga/2048.0
     else:
-	# Return a mV value for the ADS1115
-	# (Take signed values into account as well)
-	val = (result[0] << 8) | (result[1])
-	if val > 0x7FFF:
-	  return (val - 0xFFFF)*pga/32768.0
-	else:
-	  return ( (result[0] << 8) | (result[1]) )*pga/32768.0  
+      # Return a mV value for the ADS1115
+      # (Take signed values into account as well)
+      val = (result[0] << 8) | (result[1])
+      if val > 0x7FFF:
+        return (val - 0xFFFF)*pga/32768.0
+      else:
+        return ( (result[0] << 8) | (result[1]) )*pga/32768.0
 
-  def startContinuousDifferentialConversion(self, chP=0, chN=1, pga=6144, sps=250): 
+  def startContinuousDifferentialConversion(self, chP=0, chN=1, pga=6144, sps=250):
     "Starts the continuous differential conversion mode and returns the first ADC reading \
     in mV as the difference from the specified channels. \
     The sps controls the sample rate. \
     The pga must be given in mV, see datasheet page 13 for the supported values. \
     Use getLastConversionResults() to read the next values and \
     stopContinuousConversion() to stop converting."
-    
+
     # Disable comparator, Non-latching, Alert/Rdy active low
     # traditional comparator, continuous mode
     # The last flag is the only change we need, page 11 datasheet
@@ -434,24 +434,24 @@ class ADS1x15:
              self.__ADS1015_REG_CONFIG_CLAT_NONLAT  | \
              self.__ADS1015_REG_CONFIG_CPOL_ACTVLOW | \
              self.__ADS1015_REG_CONFIG_CMODE_TRAD   | \
-             self.__ADS1015_REG_CONFIG_MODE_CONTIN    
-  
+             self.__ADS1015_REG_CONFIG_MODE_CONTIN
+
     # Set sample per seconds, defaults to 250sps
     # If sps is in the dictionary (defined in init()) it returns the value of the constant
     # othewise it returns the value for 250sps. This saves a lot of if/elif/else code!
     if (self.ic == self.__IC_ADS1015):
       config |= self.spsADS1015.setdefault(sps, self.__ADS1015_REG_CONFIG_DR_1600SPS)
     else:
-      if ( (sps not in self.spsADS1115) & self.debug):	  
-	print "ADS1x15: Invalid pga specified: %d, using 6144mV" % sps     
+      if ( (sps not in self.spsADS1115) & self.debug):
+        print "ADS1x15: Invalid sps specified: %d, using 250sps" % sps
       config |= self.spsADS1115.setdefault(sps, self.__ADS1115_REG_CONFIG_DR_250SPS)
-  
+
     # Set PGA/voltage range, defaults to +-6.144V
-    if ( (pga not in self.pgaADS1x15) & self.debug):	  
-      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % sps     
+    if ( (pga not in self.pgaADS1x15) & self.debug):
+      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % pga
     config |= self.pgaADS1x15.setdefault(pga, self.__ADS1015_REG_CONFIG_PGA_6_144V)
-    self.pga = pga 
-    
+    self.pga = pga
+
     # Set channels
     if ( (chP == 0) & (chN == 1) ):
       config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_0_1
@@ -460,52 +460,52 @@ class ADS1x15:
     elif ( (chP == 2) & (chN == 3) ):
       config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_2_3
     elif ( (chP == 1) & (chN == 3) ):
-      config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_1_3  
+      config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_1_3
     else:
       if (self.debug):
-	print "ADS1x15: Invalid channels specified: %d, %d" % (chP, chN)
-	return -1  
-    
+        print "ADS1x15: Invalid channels specified: %d, %d" % (chP, chN)
+      return -1
+
     # Set 'start single-conversion' bit to begin conversions
     # No need to change this for continuous mode!
     config |= self.__ADS1015_REG_CONFIG_OS_SINGLE
-  
+
     # Write config register to the ADC
     # Once we write the ADC will convert continously
     # we can read the next values using getLastConversionResult
     bytes = [(config >> 8) & 0xFF, config & 0xFF]
     self.i2c.writeList(self.__ADS1015_REG_POINTER_CONFIG, bytes)
-  
+
     # Wait for the ADC conversion to complete
     # The minimum delay depends on the sps: delay >= 1/sps
     # We add 0.5ms to be sure
     delay = 1.0/sps+0.0005
     time.sleep(delay)
-  
+
     # Read the conversion results
     result = self.i2c.readList(self.__ADS1015_REG_POINTER_CONVERT, 2)
     if (self.ic == self.__IC_ADS1015):
-	# Shift right 4 bits for the 12-bit ADS1015 and convert to mV
-	return ( ((result[0] << 8) | (result[1] & 0xFF)) >> 4 )*pga/2048.0
+      # Shift right 4 bits for the 12-bit ADS1015 and convert to mV
+      return ( ((result[0] << 8) | (result[1] & 0xFF)) >> 4 )*pga/2048.0
     else:
-	# Return a mV value for the ADS1115
-	# (Take signed values into account as well)
-	val = (result[0] << 8) | (result[1])
-	if val > 0x7FFF:
-	  return (val - 0xFFFF)*pga/32768.0
-	else:
-	  return ( (result[0] << 8) | (result[1]) )*pga/32768.0  
+      # Return a mV value for the ADS1115
+      # (Take signed values into account as well)
+      val = (result[0] << 8) | (result[1])
+      if val > 0x7FFF:
+        return (val - 0xFFFF)*pga/32768.0
+      else:
+        return ( (result[0] << 8) | (result[1]) )*pga/32768.0
 
-	  
+
   def stopContinuousConversion(self):
     "Stops the ADC's conversions when in continuous mode \
     and resets the configuration to its default value."
     # Write the default config register to the ADC
-    # Once we write, the ADC will do a single conversion and 
+    # Once we write, the ADC will do a single conversion and
     # enter power-off mode.
     config = 0x8583 # Page 18 datasheet.
     bytes = [(config >> 8) & 0xFF, config & 0xFF]
-    self.i2c.writeList(self.__ADS1015_REG_POINTER_CONFIG, bytes)    
+    self.i2c.writeList(self.__ADS1015_REG_POINTER_CONFIG, bytes)
     return True
 
   def getLastConversionResults(self):
@@ -513,18 +513,18 @@ class ADS1x15:
     # Read the conversion results
     result = self.i2c.readList(self.__ADS1015_REG_POINTER_CONVERT, 2)
     if (self.ic == self.__IC_ADS1015):
-    	# Shift right 4 bits for the 12-bit ADS1015 and convert to mV
-    	return ( ((result[0] << 8) | (result[1] & 0xFF)) >> 4 )*self.pga/2048.0
+      # Shift right 4 bits for the 12-bit ADS1015 and convert to mV
+      return ( ((result[0] << 8) | (result[1] & 0xFF)) >> 4 )*self.pga/2048.0
     else:
-	# Return a mV value for the ADS1115
-	# (Take signed values into account as well)
-	val = (result[0] << 8) | (result[1])
-	if val > 0x7FFF:
-	  return (val - 0xFFFF)*self.pga/32768.0
-	else:
-	  return ( (result[0] << 8) | (result[1]) )*self.pga/32768.0  
-	
-	
+      # Return a mV value for the ADS1115
+      # (Take signed values into account as well)
+      val = (result[0] << 8) | (result[1])
+      if val > 0x7FFF:
+        return (val - 0xFFFF)*self.pga/32768.0
+      else:
+        return ( (result[0] << 8) | (result[1]) )*self.pga/32768.0
+
+
   def startSingleEndedComparator(self, channel, thresholdHigh, thresholdLow, \
                                  pga=6144, sps=250, \
                                  activeLow=True, traditionalMode=True, latching=False, \
@@ -540,56 +540,56 @@ class ADS1x15:
     from the one that triggered the alert) and clear the alert pin in latching mode. \
     This function starts the continuous conversion mode.  The sps controls \
     the sample rate and the pga the gain, see datasheet page 13. "
-    
+
     # With invalid channel return -1
     if (channel > 3):
       if (self.debug):
-	print "ADS1x15: Invalid channel specified: %d" % channel
+        print "ADS1x15: Invalid channel specified: %d" % channel
       return -1
-    
+
     # Continuous mode
-    config = self.__ADS1015_REG_CONFIG_MODE_CONTIN     
-    
+    config = self.__ADS1015_REG_CONFIG_MODE_CONTIN
+
     if (activeLow==False):
       config |= self.__ADS1015_REG_CONFIG_CPOL_ACTVHI
     else:
       config |= self.__ADS1015_REG_CONFIG_CPOL_ACTVLOW
-      
+
     if (traditionalMode==False):
       config |= self.__ADS1015_REG_CONFIG_CMODE_WINDOW
     else:
       config |= self.__ADS1015_REG_CONFIG_CMODE_TRAD
-      
+
     if (latching==True):
       config |= self.__ADS1015_REG_CONFIG_CLAT_LATCH
     else:
       config |= self.__ADS1015_REG_CONFIG_CLAT_NONLAT
-      
+
     if (numReadings==4):
       config |= self.__ADS1015_REG_CONFIG_CQUE_4CONV
     elif (numReadings==2):
       config |= self.__ADS1015_REG_CONFIG_CQUE_2CONV
     else:
       config |= self.__ADS1015_REG_CONFIG_CQUE_1CONV
-    
+
     # Set sample per seconds, defaults to 250sps
     # If sps is in the dictionary (defined in init()) it returns the value of the constant
     # othewise it returns the value for 250sps. This saves a lot of if/elif/else code!
     if (self.ic == self.__IC_ADS1015):
-      if ( (sps not in self.spsADS1015) & self.debug):	  
-	print "ADS1x15: Invalid sps specified: %d, using 1600sps" % sps       
+      if ( (sps not in self.spsADS1015) & self.debug):
+        print "ADS1x15: Invalid sps specified: %d, using 1600sps" % sps
       config |= self.spsADS1015.setdefault(sps, self.__ADS1015_REG_CONFIG_DR_1600SPS)
     else:
-      if ( (sps not in self.spsADS1115) & self.debug):	  
-	print "ADS1x15: Invalid sps specified: %d, using 250sps" % sps     
+      if ( (sps not in self.spsADS1115) & self.debug):
+        print "ADS1x15: Invalid sps specified: %d, using 250sps" % sps
       config |= self.spsADS1115.setdefault(sps, self.__ADS1115_REG_CONFIG_DR_250SPS)
 
     # Set PGA/voltage range, defaults to +-6.144V
-    if ( (pga not in self.pgaADS1x15) & self.debug):	  
-      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % pga     
+    if ( (pga not in self.pgaADS1x15) & self.debug):
+      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % pga
     config |= self.pgaADS1x15.setdefault(pga, self.__ADS1015_REG_CONFIG_PGA_6_144V)
     self.pga = pga
-    
+
     # Set the channel to be converted
     if channel == 3:
       config |= self.__ADS1015_REG_CONFIG_MUX_SINGLE_3
@@ -602,7 +602,7 @@ class ADS1x15:
 
     # Set 'start single-conversion' bit to begin conversions
     config |= self.__ADS1015_REG_CONFIG_OS_SINGLE
-    
+
     # Write threshold high and low registers to the ADC
     # V_digital = (2^(n-1)-1)/pga*V_analog
     if (self.ic == self.__IC_ADS1015):
@@ -610,20 +610,20 @@ class ADS1x15:
     else:
       thresholdHighWORD = int(thresholdHigh*(32767.0/pga))
     bytes = [(thresholdHighWORD >> 8) & 0xFF, thresholdHighWORD & 0xFF]
-    self.i2c.writeList(self.__ADS1015_REG_POINTER_HITHRESH, bytes) 
-  
+    self.i2c.writeList(self.__ADS1015_REG_POINTER_HITHRESH, bytes)
+
     if (self.ic == self.__IC_ADS1015):
       thresholdLowWORD = int(thresholdLow*(2048.0/pga))
     else:
-      thresholdLowWORD = int(thresholdLow*(32767.0/pga))    
+      thresholdLowWORD = int(thresholdLow*(32767.0/pga))
     bytes = [(thresholdLowWORD >> 8) & 0xFF, thresholdLowWORD & 0xFF]
-    self.i2c.writeList(self.__ADS1015_REG_POINTER_LOWTHRESH, bytes)     
+    self.i2c.writeList(self.__ADS1015_REG_POINTER_LOWTHRESH, bytes)
 
     # Write config register to the ADC
     # Once we write the ADC will convert continously and alert when things happen,
     # we can read the converted values using getLastConversionResult
     bytes = [(config >> 8) & 0xFF, config & 0xFF]
-    self.i2c.writeList(self.__ADS1015_REG_POINTER_CONFIG, bytes)    
+    self.i2c.writeList(self.__ADS1015_REG_POINTER_CONFIG, bytes)
 
 
   def startDifferentialComparator(self, chP, chN, thresholdHigh, thresholdLow, \
@@ -643,48 +643,48 @@ class ADS1x15:
     the sample rate and the pga the gain, see datasheet page 13. "
 
     # Continuous mode
-    config = self.__ADS1015_REG_CONFIG_MODE_CONTIN     
-    
+    config = self.__ADS1015_REG_CONFIG_MODE_CONTIN
+
     if (activeLow==False):
       config |= self.__ADS1015_REG_CONFIG_CPOL_ACTVHI
     else:
       config |= self.__ADS1015_REG_CONFIG_CPOL_ACTVLOW
-      
+
     if (traditionalMode==False):
       config |= self.__ADS1015_REG_CONFIG_CMODE_WINDOW
     else:
       config |= self.__ADS1015_REG_CONFIG_CMODE_TRAD
-      
+
     if (latching==True):
       config |= self.__ADS1015_REG_CONFIG_CLAT_LATCH
     else:
       config |= self.__ADS1015_REG_CONFIG_CLAT_NONLAT
-      
+
     if (numReadings==4):
       config |= self.__ADS1015_REG_CONFIG_CQUE_4CONV
     elif (numReadings==2):
       config |= self.__ADS1015_REG_CONFIG_CQUE_2CONV
     else:
       config |= self.__ADS1015_REG_CONFIG_CQUE_1CONV
-    
+
     # Set sample per seconds, defaults to 250sps
     # If sps is in the dictionary (defined in init()) it returns the value of the constant
     # othewise it returns the value for 250sps. This saves a lot of if/elif/else code!
     if (self.ic == self.__IC_ADS1015):
-      if ( (sps not in self.spsADS1015) & self.debug):	  
-	print "ADS1x15: Invalid sps specified: %d, using 1600sps" % sps       
+      if ( (sps not in self.spsADS1015) & self.debug):
+        print "ADS1x15: Invalid sps specified: %d, using 1600sps" % sps
       config |= self.spsADS1015.setdefault(sps, self.__ADS1015_REG_CONFIG_DR_1600SPS)
     else:
-      if ( (sps not in self.spsADS1115) & self.debug):	  
-	print "ADS1x15: Invalid sps specified: %d, using 250sps" % sps     
+      if ( (sps not in self.spsADS1115) & self.debug):
+        print "ADS1x15: Invalid sps specified: %d, using 250sps" % sps
       config |= self.spsADS1115.setdefault(sps, self.__ADS1115_REG_CONFIG_DR_250SPS)
 
     # Set PGA/voltage range, defaults to +-6.144V
-    if ( (pga not in self.pgaADS1x15) & self.debug):	  
-      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % pga     
+    if ( (pga not in self.pgaADS1x15) & self.debug):
+      print "ADS1x15: Invalid pga specified: %d, using 6144mV" % pga
     config |= self.pgaADS1x15.setdefault(pga, self.__ADS1015_REG_CONFIG_PGA_6_144V)
     self.pga = pga
-    
+
     # Set channels
     if ( (chP == 0) & (chN == 1) ):
       config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_0_1
@@ -693,15 +693,15 @@ class ADS1x15:
     elif ( (chP == 2) & (chN == 3) ):
       config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_2_3
     elif ( (chP == 1) & (chN == 3) ):
-      config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_1_3  
+      config |= self.__ADS1015_REG_CONFIG_MUX_DIFF_1_3
     else:
       if (self.debug):
-	print "ADS1x15: Invalid channels specified: %d, %d" % (chP, chN)
-	return -1
+        print "ADS1x15: Invalid channels specified: %d, %d" % (chP, chN)
+      return -1
 
     # Set 'start single-conversion' bit to begin conversions
     config |= self.__ADS1015_REG_CONFIG_OS_SINGLE
-    
+
     # Write threshold high and low registers to the ADC
     # V_digital = (2^(n-1)-1)/pga*V_analog
     if (self.ic == self.__IC_ADS1015):
@@ -709,18 +709,18 @@ class ADS1x15:
     else:
       thresholdHighWORD = int(thresholdHigh*(32767.0/pga))
     bytes = [(thresholdHighWORD >> 8) & 0xFF, thresholdHighWORD & 0xFF]
-    self.i2c.writeList(self.__ADS1015_REG_POINTER_HITHRESH, bytes) 
-  
+    self.i2c.writeList(self.__ADS1015_REG_POINTER_HITHRESH, bytes)
+
     if (self.ic == self.__IC_ADS1015):
       thresholdLowWORD = int(thresholdLow*(2048.0/pga))
     else:
-      thresholdLowWORD = int(thresholdLow*(32767.0/pga))    
+      thresholdLowWORD = int(thresholdLow*(32767.0/pga))
     bytes = [(thresholdLowWORD >> 8) & 0xFF, thresholdLowWORD & 0xFF]
-    self.i2c.writeList(self.__ADS1015_REG_POINTER_LOWTHRESH, bytes)     
+    self.i2c.writeList(self.__ADS1015_REG_POINTER_LOWTHRESH, bytes)
 
     # Write config register to the ADC
     # Once we write the ADC will convert continously and alert when things happen,
     # we can read the converted values using getLastConversionResult
     bytes = [(config >> 8) & 0xFF, config & 0xFF]
-    self.i2c.writeList(self.__ADS1015_REG_POINTER_CONFIG, bytes)    
+    self.i2c.writeList(self.__ADS1015_REG_POINTER_CONFIG, bytes)
 


### PR DESCRIPTION
Some minor indentation tweaks — replacing the occasional tab with spaces for consistency — and corrected several print statements which confused spa & pga references and their respective default values. 
