### PR TITLE
Add example code for 16x8 LED backpack Adafruit Item 2038/2037 etc

### DIFF
--- a/Adafruit_LEDBackpack/Adafruit_16x8.py
+++ b/Adafruit_LEDBackpack/Adafruit_16x8.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+
+import time
+import datetime
+from Adafruit_LEDBackpack import LEDBackpack
+
+# ===========================================================================
+# 16x8 Pixel Display
+# ===========================================================================
+
+class SixteenByEight:
+  disp = None
+
+  # Constructor
+  def __init__(self, address=0x70, debug=False):
+    if (debug):
+      print "Initializing a new instance of LEDBackpack at 0x%02X" % address
+    self.disp = LEDBackpack(address=address, debug=debug)
+
+  def writeRowRaw(self, charNumber, value):
+    "Sets a row of pixels using a raw 16-bit value"
+    if (charNumber > 7):
+      return
+    # Set the appropriate row
+    self.disp.setBufferRow(charNumber, value)
+
+  def clearPixel(self, x, y):
+    "A wrapper function to clear pixels (purely cosmetic)"
+    self.setPixel(x, y, 0)
+
+  def setPixel(self, x, y, color=1):
+    "Sets a single pixel"
+    if (x >= 16):
+      return
+    if (y >= 8):
+      return    
+    x += 16   # ATTN: This might be a bug?  On the color matrix, this causes x=0 to draw on the last line instead of the first.
+    x %= 16
+    # Set the appropriate pixel
+    buffer = self.disp.getBuffer()
+    if (color):
+      self.disp.setBufferRow(y, buffer[y] | 1 << x)
+    else:
+      self.disp.setBufferRow(y, buffer[y] & ~(1 << x))
+
+  def clear(self):
+    "Clears the entire display"
+    self.disp.clear()

--- a/Adafruit_LEDBackpack/ex_16x8_pixels.py
+++ b/Adafruit_LEDBackpack/ex_16x8_pixels.py
@@ -13,8 +13,8 @@ print "Press CTRL+Z to exit"
 
 # Continually update the 16x8 display one pixel at a time
 while(True):
-  for x in range(0, 8):
-    for y in range(0, 16):
+  for x in range(0, 16):
+    for y in range(0, 8):
       grid.setPixel(x, y)
       time.sleep(0.05)
   time.sleep(0.5)

--- a/Adafruit_LEDBackpack/ex_16x8_pixels.py
+++ b/Adafruit_LEDBackpack/ex_16x8_pixels.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+import time
+import datetime
+from Adafruit_16x8 import SixteenByEight
+
+# ===========================================================================
+# 16x8 Pixel Example
+# ===========================================================================
+grid = SixteenByEight(address=0x70)
+
+print "Press CTRL+Z to exit"
+
+# Continually update the 16x8 display one pixel at a time
+while(True):
+  for x in range(0, 8):
+    for y in range(0, 16):
+      grid.setPixel(x, y)
+      time.sleep(0.05)
+  time.sleep(0.5)
+  grid.clear()
+  time.sleep(0.5)

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+##Shockley Fork
+
+This fork has added example code for a 16x8 LED matrix.  In doing so, two additional python files were added:
+ex_16x8_pixels.py
+Adafruit_16x8.py
+
+These files can be used to demonstrate using a 16x8 LED matrix, such as [item # 2054 available at Adafruit.com.](http://www.adafruit.com/products/2054)


### PR DESCRIPTION
This branch added two files:
Adafruit_16x8.py
ex_16x8_pixels.py

These files are almost identical to their 8x8 sisters, but modified to work with the 16x8 backpacks.  I removed references to color backpacks as I don't think they exist.
