### PR TITLE
Fixes Github Issue 140 in Adafruit's repository

### DIFF
--- a/Adafruit_LEDpixels/Adafruit_LEDpixels.py
+++ b/Adafruit_LEDpixels/Adafruit_LEDpixels.py
@@ -70,7 +70,7 @@ def rainbowCycle(pixels, wait):
 # (thats the i / strip.numPixels() part)
 # Then add in j which makes the colors go around per pixel
 # the % 96 is to make the wheel cycle around
-      		setpixelcolor(pixels, i, Wheel( ((i * 256 / len(pixels)) + j) % 256) )
+      		setpixelcolor(pixels, i, Wheel( ((i * 256 // len(pixels)) + j) % 256) )
 	   writestrip(pixels)
 	   time.sleep(wait)
 


### PR DESCRIPTION
This change was made in response to a Github Issue #140 
and a question on an Adafruit forum:
https://forums.adafruit.com/viewtopic.php?f=47&t=85731&p=432043&sid=584c7d7c80739693b81e5e0112c7c104#p432043)

The error comes from this line:
https://github.com/adafruit/Adafruit-Raspberry-Pi-Python-Code/blob/master/Adafruit_LEDpixels/Adafruit_LEDpixels.py#L73

The error was caused by Python3 using floating point division when
Python2 would use integer division. The change uses a `//` instead
of `/` which forces both languages to use integer division.

In Python2, `10 / 3` gives `3`
In Python3, `10 / 3` gives `3.333333`

After the change:

In Python2, `10 // 3` gives `3`
In Python3, `10 // 3` gives `3`

The output of the code is now the same, regardless of Python 2 vs. 3 as tested on my interpreters (2.7.6 and 3.5.1).
